### PR TITLE
ThingSpeak returns "0" when there was an error updating a channel feed.

### DIFF
--- a/ThingSpeakWinRT/Exceptions/InvalidResponseException.cs
+++ b/ThingSpeakWinRT/Exceptions/InvalidResponseException.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ThingSpeakWinRT.Exceptions
+{
+    public class InvalidResponseException : Exception
+    {
+        public InvalidResponseException() : base() { }
+        public InvalidResponseException(string message) : base(message) { }
+        public InvalidResponseException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/ThingSpeakWinRT/ThingSpeakWinRT.csproj
+++ b/ThingSpeakWinRT/ThingSpeakWinRT.csproj
@@ -38,6 +38,7 @@
     <TargetPlatform Include="Windows, Version=8.1" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Exceptions\InvalidResponseException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ThingSpeakChannel.cs" />
     <Compile Include="ThingSpeakClient.cs" />


### PR DESCRIPTION
To support that, I Added code that verifies if the response is a "valid" JSON or not (first check, if it just starts and ends with curly braces)

If it is not a JSON, then I assume there was an error updating the feed.

In case we did receive a JSON response but there was a problem parsing it, then I added an Exception to report that to the user.

Since that is working fine for me, I though you might want to integrate it to your app or at least be aware of it.

Let me know either way or if you would want me to make any changes.

Daniel.
